### PR TITLE
Update workflow to add nightly-6.3 version and armv7 arch

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -7,8 +7,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        swift: ['6.2.3']
-        arch: ['aarch64', 'x86_64']
+        swift: ['6.2.3', 'nightly-6.3']
+        arch: ['aarch64', 'x86_64', 'armv7']
         sdk: ['28', '29', '31', '33']
     runs-on: macos-15
     timeout-minutes: 30


### PR DESCRIPTION
This PR adds both the `nightly-6.3` version, which will use the upcoming official 6.3 version of the Swift SDK for Android, as well as the `armv7` architecture.

There are some failures that I will document, so you may want to hold off on merging until these are addressed.