### PR TITLE
Link against SwiftJavaStatic instead of SwiftJava

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -102,7 +102,7 @@ var package = Package(
       name: "AndroidKit",
       dependencies: [
         .product(
-          name: "SwiftJava",
+          name: "SwiftJavaStatic",
           package: "swift-java"
         ),
         .product(
@@ -171,7 +171,7 @@ var package = Package(
       name: "AndroidJava",
       dependencies: [
         .product(
-          name: "SwiftJava",
+          name: "SwiftJavaStatic",
           package: "swift-java"
         ),
         .product(


### PR DESCRIPTION
## Summary
swift-java's own `Package.swift` declares its `SwiftJava` product as `type: .dynamic`, with a target (`SwiftJavaRuntimeSupport`) that statically depends on that same product's other target (`SwiftJava`). SwiftPM rejects this graph whenever any other dynamic library product also exists in the resolution — which happens for any app embedding AndroidKit into its own single `.so` (e.g. via a JNI bridge). `SwiftJavaStatic` is the product swift-java itself documents as the correct choice for static-linking consumers.

## Test plan
- [x] Cross-compiled an app depending on AndroidKit for `aarch64-unknown-linux-android` with this change; the duplicate-linkage error is gone.