### PR TITLE
Declare Apple platform requirements and align swift-android-native source

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,14 @@ let ndkBinder = sdkVersion >= 29  // binder_ndk Requires API 29
 var package = Package(
   name: "SwiftAndroid",
   platforms: [
-    .macOS(.v15)
+    .macOS(.v15),
+    // Declared to match the Socket/Bluetooth dependencies. This package only ever builds for
+    // Android, but SwiftPM validates platform requirements across the whole graph, and leaving
+    // these unspecified defaults them to iOS 12 — which conflicts with dependencies requiring
+    // iOS 13 and breaks any Apple-platform resolve of a package that includes it.
+    .iOS(.v13),
+    .watchOS(.v6),
+    .tvOS(.v13)
   ],
   products: [
     .library(
@@ -92,9 +99,12 @@ var package = Package(
       url: "https://github.com/PureSwift/Kotlin.git",
       branch: "master"
     ),
+    // Must match the source skip-android-bridge uses: SwiftPM resolves by package identity, so
+    // pointing at the upstream URL here while skip-android-bridge points at the fork makes the
+    // identity `swift-android-native` unresolvable ("two different revision-based requirements").
     .package(
-      url: "https://github.com/swift-android-sdk/swift-android-native.git",
-      branch: "main"
+      url: "https://github.com/MillerTechnologyPeru/swift-android-native.git",
+      branch: "feature/pureswift"
     ),
   ],
   targets: [


### PR DESCRIPTION
Two manifest fixes found while building a downstream app (BluetoothExplorer) that depends on this
package transitively.

## Declare Apple platform requirements

The package declared only `.macOS(.v15)`. SwiftPM defaults unspecified platforms to iOS 12, while
`Socket`/`Bluetooth` and friends require iOS 13 — so *any* Apple-platform resolve of a graph
containing this package failed:

```
the library 'AndroidLooper' requires ios 12.0, but depends on the product 'Socket'
which requires ios 13.0; consider changing the library 'AndroidLooper' to require
ios 13.0 or later, or the product 'Socket' to require ios 12.0 or earlier
```

That was 4 of 15 such errors in the downstream app; the rest came from `AndroidBluetooth`
(PureSwift/AndroidBluetooth#…) and swift-java.

Now declares `.iOS(.v13), .watchOS(.v6), .tvOS(.v13)` to match the dependencies. This package only
ever builds for Android, but SwiftPM validates platform requirements across the whole graph
regardless of `.when(platforms:)` conditions, so the declaration has to be there.

## Align the swift-android-native source

This package pointed at `swift-android-sdk/swift-android-native` @ `main`, while
`MillerTechnologyPeru/skip-android-bridge` points at
`MillerTechnologyPeru/swift-android-native` @ `feature/pureswift`. SwiftPM resolves by package
*identity*, so a graph containing both is unresolvable:

```
error: swift-android-native is required using two different revision-based requirements
(feature/pureswift and main), which is not supported
```

Now points at the same fork/branch the bridge uses.

**Note:** this depends on MillerTechnologyPeru/swift-android-native#… (merging current upstream
`main` into `feature/pureswift`), because the fork was 87 commits behind and did not yet export
`AndroidManifest`, `AndroidFileManager`, `AndroidInput` or `AndroidHardware`, which this package
requires. Merge that first.
