### PR TITLE
Build with the official Swift Android SDK 6.3.2 in Docker

### DIFF
--- a/.github/docker/Dockerfile
+++ b/.github/docker/Dockerfile
@@ -12,4 +12,10 @@ RUN apt-get update \
 RUN swift sdk install "$SWIFT_SDK_URL" --checksum "$SWIFT_SDK_CHECKSUM" \
     && swift sdk list
 
+# record the triples the installed Swift SDK supports, so a build can select one by architecture
+RUN find / -path '*swift-sdks*' -name 'swift-sdk.json' -exec cat {} + \
+    | grep -o '"[a-z0-9_]*-unknown-linux-android[a-z]*[0-9]*"' \
+    | tr -d '"' | sort -u > /usr/local/share/swift-android-triples \
+    && cat /usr/local/share/swift-android-triples
+
 WORKDIR /package

--- a/.github/docker/Dockerfile
+++ b/.github/docker/Dockerfile
@@ -2,18 +2,14 @@
 # Swift SDK for Android.
 FROM swift:6.3.2-noble
 
-ARG SWIFT_SDK_URL=https://download.swift.org/swift-6.3.2-release/android/swift-6.3.2-RELEASE/swift-6.3.2-RELEASE-android-24-0.1.artifactbundle.tar.gz
-ARG SWIFT_SDK_CHECKSUM=
+ARG SWIFT_SDK_URL=https://download.swift.org/swift-6.3.2-release/android-sdk/swift-6.3.2-RELEASE/swift-6.3.2-RELEASE_android.artifactbundle.tar.gz
+ARG SWIFT_SDK_CHECKSUM=939e933549d12d28f2e0bf71019d734d309859e9773c572657ce565a81f85d68
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends ca-certificates curl unzip \
     && rm -rf /var/lib/apt/lists/*
 
-RUN if [ -n "$SWIFT_SDK_CHECKSUM" ]; then \
-        swift sdk install "$SWIFT_SDK_URL" --checksum "$SWIFT_SDK_CHECKSUM"; \
-    else \
-        swift sdk install "$SWIFT_SDK_URL"; \
-    fi \
+RUN swift sdk install "$SWIFT_SDK_URL" --checksum "$SWIFT_SDK_CHECKSUM" \
     && swift sdk list
 
 WORKDIR /package

--- a/.github/docker/Dockerfile
+++ b/.github/docker/Dockerfile
@@ -23,9 +23,10 @@ RUN mkdir -p "$(dirname "$ANDROID_NDK_HOME")" \
 RUN swift sdk install "$SWIFT_SDK_URL" --checksum "$SWIFT_SDK_CHECKSUM" \
     && swift sdk list
 
-# the artifact bundle expects the NDK sysroot at `ndk-sysroot` inside the bundle
+# the bundle ships a script that links the NDK sysroot, the clang resource
+# directory and swiftrt.o into place, using ANDROID_NDK_HOME
 RUN BUNDLE=$(dirname "$(find / -path '*swift-sdks*' -name 'swift-sdk.json' | head -1)") \
-    && ln -s "$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/sysroot" "$BUNDLE/ndk-sysroot" \
+    && "$BUNDLE/scripts/setup-android-sdk.sh" \
     && test -f "$BUNDLE/ndk-sysroot/usr/include/jni.h"
 
 WORKDIR /package

--- a/.github/docker/Dockerfile
+++ b/.github/docker/Dockerfile
@@ -1,0 +1,19 @@
+# Build image for cross-compiling the package with the official
+# Swift SDK for Android.
+FROM swift:6.3.2-noble
+
+ARG SWIFT_SDK_URL=https://download.swift.org/swift-6.3.2-release/android/swift-6.3.2-RELEASE/swift-6.3.2-RELEASE-android-24-0.1.artifactbundle.tar.gz
+ARG SWIFT_SDK_CHECKSUM=
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates curl unzip \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN if [ -n "$SWIFT_SDK_CHECKSUM" ]; then \
+        swift sdk install "$SWIFT_SDK_URL" --checksum "$SWIFT_SDK_CHECKSUM"; \
+    else \
+        swift sdk install "$SWIFT_SDK_URL"; \
+    fi \
+    && swift sdk list
+
+WORKDIR /package

--- a/.github/docker/Dockerfile
+++ b/.github/docker/Dockerfile
@@ -4,18 +4,28 @@ FROM swift:6.3.2-noble
 
 ARG SWIFT_SDK_URL=https://download.swift.org/swift-6.3.2-release/android-sdk/swift-6.3.2-RELEASE/swift-6.3.2-RELEASE_android.artifactbundle.tar.gz
 ARG SWIFT_SDK_CHECKSUM=939e933549d12d28f2e0bf71019d734d309859e9773c572657ce565a81f85d68
+ARG ANDROID_NDK_VERSION=r27d
+
+ENV ANDROID_NDK_HOME=/usr/local/lib/android/sdk/ndk/${ANDROID_NDK_VERSION}
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends ca-certificates curl unzip \
     && rm -rf /var/lib/apt/lists/*
 
+# the Swift SDK links against the NDK sysroot, which it does not bundle
+RUN mkdir -p "$(dirname "$ANDROID_NDK_HOME")" \
+    && curl -fsSL -o /tmp/ndk.zip \
+        "https://dl.google.com/android/repository/android-ndk-${ANDROID_NDK_VERSION}-linux.zip" \
+    && unzip -q /tmp/ndk.zip -d /tmp \
+    && mv "/tmp/android-ndk-${ANDROID_NDK_VERSION}" "$ANDROID_NDK_HOME" \
+    && rm /tmp/ndk.zip
+
 RUN swift sdk install "$SWIFT_SDK_URL" --checksum "$SWIFT_SDK_CHECKSUM" \
     && swift sdk list
 
-# record the triples the installed Swift SDK supports, so a build can select one by architecture
-RUN find / -path '*swift-sdks*' -name 'swift-sdk.json' -exec cat {} + \
-    | grep -o '"[a-z0-9_]*-unknown-linux-android[a-z]*[0-9]*"' \
-    | tr -d '"' | sort -u > /usr/local/share/swift-android-triples \
-    && cat /usr/local/share/swift-android-triples
+# the artifact bundle expects the NDK sysroot at `ndk-sysroot` inside the bundle
+RUN BUNDLE=$(dirname "$(find / -path '*swift-sdks*' -name 'swift-sdk.json' | head -1)") \
+    && ln -s "$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/sysroot" "$BUNDLE/ndk-sysroot" \
+    && test -f "$BUNDLE/ndk-sysroot/usr/include/jni.h"
 
 WORKDIR /package

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   android:
-    name: Android (Swift SDK ${{ matrix.swift }} / API ${{ matrix.android-api }})
+    name: Android (Swift SDK ${{ matrix.swift }} / API ${{ matrix.android-api }} / ${{ matrix.arch }})
     runs-on: ubuntu-24.04
     timeout-minutes: 90
     strategy:
@@ -34,12 +34,20 @@ jobs:
             armv7)   TRIPLE="armv7-unknown-linux-androideabi${{ matrix.android-api }}" ;;
             x86_64)  TRIPLE="x86_64-unknown-linux-android${{ matrix.android-api }}" ;;
           esac
-          SDK="$(echo "$TRIPLE" | sed 's/[0-9]*$/24/')"
           docker run --rm \
             --volume "$PWD:/package" \
             --env ANDROID_SDK_VERSION=${{ matrix.android-api }} \
+            --env TRIPLE="$TRIPLE" \
             swift-android-sdk:${{ matrix.swift }} \
-            swift build \
-              --swift-sdk "$SDK" \
-              -Xswiftc -target -Xswiftc "$TRIPLE" \
-              -Xcc -target -Xcc "$TRIPLE"
+            bash -c '
+              set -eu
+              # the installed Swift SDK identifier carries its own minimum API level,
+              # so look it up by architecture and override the target triple below
+              PREFIX=$(echo "$TRIPLE" | sed "s/[0-9]*$//")
+              SDK=$(swift sdk list | grep -m1 "^$PREFIX")
+              echo "Using Swift SDK: $SDK (target $TRIPLE)"
+              swift build \
+                --swift-sdk "$SDK" \
+                -Xswiftc -target -Xswiftc "$TRIPLE" \
+                -Xcc -target -Xcc "$TRIPLE"
+            '

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -30,24 +30,20 @@ jobs:
       - name: "Build Swift Package for Android (${{ matrix.arch }})"
         run: |
           case "${{ matrix.arch }}" in
-            aarch64) TRIPLE="aarch64-unknown-linux-android${{ matrix.android-api }}" ;;
-            armv7)   TRIPLE="armv7-unknown-linux-androideabi${{ matrix.android-api }}" ;;
-            x86_64)  TRIPLE="x86_64-unknown-linux-android${{ matrix.android-api }}" ;;
+            aarch64) PREFIX="aarch64-unknown-linux-android" ;;
+            armv7)   PREFIX="armv7-unknown-linux-androideabi" ;;
+            x86_64)  PREFIX="x86_64-unknown-linux-android" ;;
           esac
           docker run --rm \
             --volume "$PWD:/package" \
             --env ANDROID_SDK_VERSION=${{ matrix.android-api }} \
-            --env TRIPLE="$TRIPLE" \
+            --env PREFIX="$PREFIX" \
             swift-android-sdk:${{ matrix.swift }} \
             bash -c '
               set -eu
-              # the Swift SDK ships a fixed minimum API level per triple,
-              # so select it by architecture and override the target triple below
-              PREFIX=$(echo "$TRIPLE" | sed "s/[0-9]*$//")
+              # the Swift SDK bundles one sysroot per architecture with its own
+              # minimum API level; ANDROID_SDK_VERSION selects the package features
               SDK=$(grep -m1 "^$PREFIX" /usr/local/share/swift-android-triples)
-              echo "Using Swift SDK: $SDK (target $TRIPLE)"
-              swift build \
-                --swift-sdk "$SDK" \
-                -Xswiftc -target -Xswiftc "$TRIPLE" \
-                -Xcc -target -Xcc "$TRIPLE"
+              echo "Using Swift SDK: $SDK (ANDROID_SDK_VERSION=$ANDROID_SDK_VERSION)"
+              swift build --swift-sdk "$SDK"
             '

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,45 @@
+name: Docker
+
+on:
+  push:
+    branches: [master]
+  workflow_dispatch:
+  pull_request:
+
+jobs:
+  android:
+    name: Android (Swift SDK ${{ matrix.swift }} / API ${{ matrix.android-api }})
+    runs-on: ubuntu-24.04
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        swift: ['6.3.2']
+        android-api: ['28', '29', '31', '33']
+        arch: ['aarch64', 'armv7', 'x86_64']
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: "Build Docker image"
+        run: |
+          docker build \
+            --tag swift-android-sdk:${{ matrix.swift }} \
+            --file .github/docker/Dockerfile \
+            .github/docker
+
+      - name: "Build Swift Package for Android (${{ matrix.arch }})"
+        run: |
+          case "${{ matrix.arch }}" in
+            aarch64) TRIPLE="aarch64-unknown-linux-android${{ matrix.android-api }}" ;;
+            armv7)   TRIPLE="armv7-unknown-linux-androideabi${{ matrix.android-api }}" ;;
+            x86_64)  TRIPLE="x86_64-unknown-linux-android${{ matrix.android-api }}" ;;
+          esac
+          SDK="$(echo "$TRIPLE" | sed 's/[0-9]*$/24/')"
+          docker run --rm \
+            --volume "$PWD:/package" \
+            --env ANDROID_SDK_VERSION=${{ matrix.android-api }} \
+            swift-android-sdk:${{ matrix.swift }} \
+            swift build \
+              --swift-sdk "$SDK" \
+              -Xswiftc -target -Xswiftc "$TRIPLE" \
+              -Xcc -target -Xcc "$TRIPLE"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -42,5 +42,5 @@ jobs:
             bash -c '
               set -eu
               # the prebuilt swift-syntax bundle omits SwiftIfConfig, which swift-java needs
-              swift build --swift-sdk "$TRIPLE" --disable-prebuilts
+              swift build --swift-sdk "$TRIPLE" --disable-experimental-prebuilts
             '

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -41,10 +41,10 @@ jobs:
             swift-android-sdk:${{ matrix.swift }} \
             bash -c '
               set -eu
-              # the installed Swift SDK identifier carries its own minimum API level,
-              # so look it up by architecture and override the target triple below
+              # the Swift SDK ships a fixed minimum API level per triple,
+              # so select it by architecture and override the target triple below
               PREFIX=$(echo "$TRIPLE" | sed "s/[0-9]*$//")
-              SDK=$(swift sdk list | grep -m1 "^$PREFIX")
+              SDK=$(grep -m1 "^$PREFIX" /usr/local/share/swift-android-triples)
               echo "Using Swift SDK: $SDK (target $TRIPLE)"
               swift build \
                 --swift-sdk "$SDK" \

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -30,20 +30,17 @@ jobs:
       - name: "Build Swift Package for Android (${{ matrix.arch }})"
         run: |
           case "${{ matrix.arch }}" in
-            aarch64) PREFIX="aarch64-unknown-linux-android" ;;
-            armv7)   PREFIX="armv7-unknown-linux-androideabi" ;;
-            x86_64)  PREFIX="x86_64-unknown-linux-android" ;;
+            aarch64) TRIPLE="aarch64-unknown-linux-android${{ matrix.android-api }}" ;;
+            armv7)   TRIPLE="armv7-unknown-linux-android${{ matrix.android-api }}" ;;
+            x86_64)  TRIPLE="x86_64-unknown-linux-android${{ matrix.android-api }}" ;;
           esac
           docker run --rm \
             --volume "$PWD:/package" \
             --env ANDROID_SDK_VERSION=${{ matrix.android-api }} \
-            --env PREFIX="$PREFIX" \
+            --env TRIPLE="$TRIPLE" \
             swift-android-sdk:${{ matrix.swift }} \
             bash -c '
               set -eu
-              # the Swift SDK bundles one sysroot per architecture with its own
-              # minimum API level; ANDROID_SDK_VERSION selects the package features
-              SDK=$(grep -m1 "^$PREFIX" /usr/local/share/swift-android-triples)
-              echo "Using Swift SDK: $SDK (ANDROID_SDK_VERSION=$ANDROID_SDK_VERSION)"
-              swift build --swift-sdk "$SDK"
+              # the prebuilt swift-syntax bundle omits SwiftIfConfig, which swift-java needs
+              swift build --swift-sdk "$TRIPLE" --disable-prebuilts
             '


### PR DESCRIPTION
Adds a Docker-based CI job that cross-compiles the package with the official Swift SDK for Android 6.3.2.

**`.github/docker/Dockerfile`** — `swift:6.3.2-noble` plus:
- the official Android artifact bundle, installed via `swift sdk install` with the swift.org checksum (both overridable via build args)
- Android NDK r27d, wired in by the bundle's own `scripts/setup-android-sdk.sh`, which links the NDK sysroot, the clang resource directory and `swiftrt.o` into the bundle (the bundle references `ndk-sysroot` but does not ship it)

**`.github/workflows/docker.yml`** — matrix over API levels 28/29/31/33 and aarch64/armv7/x86_64. The bundle declares triples for API 28–36, so each job selects the matching triple directly and sets `ANDROID_SDK_VERSION` for the package's feature defines. `--disable-experimental-prebuilts` is needed because the prebuilt swift-syntax bundle omits `SwiftIfConfig`, which swift-java requires.

All 12 jobs pass. The existing `swift.yml` workflow is unchanged.